### PR TITLE
Resolve error "rtnetlink.h is required"

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,5 +1,8 @@
 FROM php:8.1-fpm-alpine
 
+# install linux headers package
+RUN apk add --update linux-headers
+
 RUN \
     apk add --no-cache $PHPIZE_DEPS su-exec postgresql-dev tidyhtml tidyhtml-dev git libpng-dev libjpeg-turbo-dev freetype-dev tar libzip-dev zip && \
     pecl install xdebug && \


### PR DESCRIPTION
I was having issues running the demo. 

#0 31.64 configure: error: rtnetlink.h is required, install the linux-headers package: apk add --update linux-headers

The changes proposed solved it.